### PR TITLE
Add Jira issue context in replies

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,6 +14,11 @@ disturbing a real human.
 2. Provide Slack credentials in `/etc/ai-chat-bot`:
    - `/etc/ai-chat-bot/slack-token` – Slack bot token
    - `/etc/ai-chat-bot/slack-signing-secret` – Slack signing secret
+4. Configure Jira access through the following environment variables:
+   - `JIRA_BASE_URL` – Base URL of your Jira instance (e.g. `https://yourdomain.atlassian.net`)
+   - `JIRA_USERNAME` – Username or e‑mail address used to authenticate
+   - `JIRA_TOKEN` – API token generated from Jira
+   - `JIRA_PROJECT_KEY` – Project key where issues should be created
 3. Run the application with Go:
 
 ```bash
@@ -34,3 +39,16 @@ The bot listens to Slack events, sends the message history to Bedrock and replie
 
 - AWS keys injected as environment variables
 - Slack workspace keys
+- Jira variables for issue creation
+
+### Creating Jira tickets
+
+Send a Slack message starting with `jira create` followed by a summary. The bot
+will create a new issue in the configured project and reply with the created
+issue key.
+
+### Using Jira links for context
+
+If your message contains a link to a Jira issue, the bot will fetch the ticket's
+summary and description and include it when generating a response. This helps
+produce more accurate answers when discussing existing tasks.

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module ai-bot
 go 1.24.4
 
 require (
+	github.com/andygrunwald/go-jira v1.15.0
 	github.com/aws/aws-sdk-go v1.55.7
 	github.com/aws/aws-sdk-go-v2 v1.36.5
 	github.com/aws/aws-sdk-go-v2/config v1.29.17
@@ -10,8 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/bedrockagentruntime v1.45.2
 	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.31.0
 	github.com/guregu/dynamo v1.23.0
-       github.com/slack-go/slack v0.17.3
-       github.com/andygrunwald/go-jira v1.15.0
+	github.com/slack-go/slack v0.17.3
 )
 
 require (
@@ -27,7 +27,12 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.34.0 // indirect
 	github.com/aws/smithy-go v1.22.4 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
+	github.com/fatih/structs v1.1.0 // indirect
+	github.com/golang-jwt/jwt/v4 v4.3.0 // indirect
+	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/trivago/tgo v1.0.7 // indirect
 	golang.org/x/sync v0.15.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/bedrockagentruntime v1.45.2
 	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.31.0
 	github.com/guregu/dynamo v1.23.0
-	github.com/slack-go/slack v0.17.3
+       github.com/slack-go/slack v0.17.3
+       github.com/andygrunwald/go-jira v1.15.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/andygrunwald/go-jira v1.15.0 h1:krX3Ad4i44mOG0u+vIxQLhLkyyQKPbTsOISsDRgBNjU=
+github.com/andygrunwald/go-jira v1.15.0/go.mod h1:GIYN1sHOIsENWUZ7B4pDeT/nxEtrZpE8l0987O67ZR8=
 github.com/aws/aws-sdk-go v1.55.7 h1:UJrkFq7es5CShfBwlWAC8DA077vp8PyVbQd3lqLiztE=
 github.com/aws/aws-sdk-go v1.55.7/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/aws/aws-sdk-go-v2 v1.36.5 h1:0OF9RiEMEdDdZEMqF9MRjevyxAQcf6gY+E7vwBILFj0=
@@ -37,8 +39,17 @@ github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyY
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
+github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=
 github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
+github.com/golang-jwt/jwt/v4 v4.3.0 h1:kHL1vqdqWNfATmA0FNMdmZNMyZI1U6O31X4rlIPoBog=
+github.com/golang-jwt/jwt/v4 v4.3.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
+github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/guregu/dynamo v1.23.0 h1:lKiHpT1Io3DtAxzhgM3+kyidRSk7/u6nld7kgcP6W7U=
@@ -47,6 +58,8 @@ github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9Y
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/slack-go/slack v0.17.3 h1:zV5qO3Q+WJAQ/XwbGfNFrRMaJ5T/naqaonyPV/1TP4g=
@@ -54,8 +67,13 @@ github.com/slack-go/slack v0.17.3/go.mod h1:X+UqOufi3LYQHDnMG1vxf0J8asC6+WllXrVr
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/trivago/tgo v1.0.7 h1:uaWH/XIy9aWYWpjm2CU3RpcqZXmX2ysQ9/Go+d9gyrM=
+github.com/trivago/tgo v1.0.7/go.mod h1:w4dpD+3tzNIIiIfkWWa85w5/B77tlvdZckQ+6PkFnhc=
 golang.org/x/sync v0.15.0 h1:KWH3jNZsfyT6xfAfKiz6MRNmd46ByHDYaZ7KSkCtdW8=
 golang.org/x/sync v0.15.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/internal/jira/service.go
+++ b/internal/jira/service.go
@@ -1,0 +1,50 @@
+package jira
+
+import (
+	"github.com/andygrunwald/go-jira"
+)
+
+// Service handles operations with Jira.
+type Service struct {
+	client     *jira.Client
+	projectKey string
+}
+
+// NewService creates a Jira service using basic auth.
+func NewService(baseURL, username, apiToken, projectKey string) (*Service, error) {
+	tp := jira.BasicAuthTransport{
+		Username: username,
+		Password: apiToken,
+	}
+	client, err := jira.NewClient(tp.Client(), baseURL)
+	if err != nil {
+		return nil, err
+	}
+	return &Service{client: client, projectKey: projectKey}, nil
+}
+
+// CreateIssue creates a new issue in Jira and returns its key.
+func (s *Service) CreateIssue(summary, description string) (string, error) {
+	issue := &jira.Issue{
+		Fields: &jira.IssueFields{
+			Summary:     summary,
+			Description: description,
+			Type:        jira.IssueType{Name: "Task"},
+			Project:     jira.Project{Key: s.projectKey},
+		},
+	}
+	created, _, err := s.client.Issue.Create(issue)
+	if err != nil {
+		return "", err
+	}
+	return created.Key, nil
+}
+
+// IssueInfo returns the summary and description of the issue with the given key.
+func (s *Service) IssueInfo(key string) (string, string, error) {
+	issue, _, err := s.client.Issue.Get(key, nil)
+	if err != nil {
+		return "", "", err
+	}
+	return issue.Fields.Summary, issue.Fields.Description, nil
+}


### PR DESCRIPTION
## Summary
- extend Jira service with IssueInfo method
- detect Jira links in Slack messages and include issue summary & description in prompts
- document use of Jira links for additional context

## Testing
- `gofmt -w main.go internal/jira/service.go`
- ❌ `go vet ./...` *(fails: Forbidden)*
- ❌ `go mod tidy` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6868d0618d1483318a2824d90a0e0ce9